### PR TITLE
Add inference pipeline base class to streamline composed pipelines

### DIFF
--- a/docs/source/design/overview.md
+++ b/docs/source/design/overview.md
@@ -64,16 +64,23 @@ with set_current_fastvideo_args(fastvideo_args):
 (design-pipeline-system)=
 ## Pipeline System
 
-### `ComposedPipelineBase`
+### `ComposedPipelineBase` and `InferencePipeline`
 
-This foundational class provides:
+`ComposedPipelineBase` provides the shared foundation for all composed pipelines:
 
 - **Model Loading**: Automatically loads components from HuggingFace-Diffusers-compatible model directories
 - **Stage Management**: Creates and orchestrates processing stages
 - **Data Flow Coordination**: Ensures proper state flow between stages
 
+Inference pipelines typically derive from :class:`fastvideo.pipelines.inference_pipeline.InferencePipeline`,
+which extends :class:`~fastvideo.pipelines.composed_pipeline_base.ComposedPipelineBase` with inference-specific setup
+such as Torch Compile integration and stage construction.
+
 ```python
-class MyCustomPipeline(ComposedPipelineBase):
+from fastvideo.pipelines.inference_pipeline import InferencePipeline
+
+
+class MyCustomPipeline(InferencePipeline):
     _required_config_modules = [
         "text_encoder", "tokenizer", "vae", "transformer", "scheduler"
     ]

--- a/docs/source/inference/add_pipeline.md
+++ b/docs/source/inference/add_pipeline.md
@@ -167,7 +167,7 @@ Pipelines are composed of stages, each handling a specific part of the diffusion
 ### Creating Your Pipeline
 
 ```python
-from fastvideo.pipelines.composed_pipeline_base import ComposedPipelineBase
+from fastvideo.pipelines.inference_pipeline import InferencePipeline
 from fastvideo.pipelines.stages import (
     InputValidationStage, CLIPTextEncodingStage, TimestepPreparationStage,
     LatentPreparationStage, DenoisingStage, DecodingStage
@@ -176,7 +176,7 @@ from fastvideo.fastvideo_args import FastVideoArgs
 from fastvideo.pipelines.pipeline_batch_info import ForwardBatch
 import torch
 
-class MyCustomPipeline(ComposedPipelineBase):
+class MyCustomPipeline(InferencePipeline):
     """Custom diffusion pipeline implementation."""
     
     # Define required model components from model_index.json

--- a/fastvideo/pipelines/__init__.py
+++ b/fastvideo/pipelines/__init__.py
@@ -10,6 +10,7 @@ from typing import cast
 from fastvideo.fastvideo_args import FastVideoArgs
 from fastvideo.logger import init_logger
 from fastvideo.pipelines.composed_pipeline_base import ComposedPipelineBase
+from fastvideo.pipelines.inference_pipeline import InferencePipeline
 from fastvideo.pipelines.lora_pipeline import LoRAPipeline
 from fastvideo.pipelines.pipeline_batch_info import ForwardBatch, TrainingBatch
 from fastvideo.pipelines.pipeline_registry import (PipelineType,
@@ -20,7 +21,7 @@ from fastvideo.utils import (maybe_download_model,
 logger = init_logger(__name__)
 
 
-class PipelineWithLoRA(LoRAPipeline, ComposedPipelineBase):
+class PipelineWithLoRA(LoRAPipeline):
     """Type for a pipeline that has both ComposedPipelineBase and LoRAPipeline functionality."""
     pass
 
@@ -72,6 +73,7 @@ def build_pipeline(
 __all__ = [
     "build_pipeline",
     "ComposedPipelineBase",
+    "InferencePipeline",
     "ForwardBatch",
     "LoRAPipeline",
     "TrainingBatch",

--- a/fastvideo/pipelines/basic/hunyuan/hunyuan_pipeline.py
+++ b/fastvideo/pipelines/basic/hunyuan/hunyuan_pipeline.py
@@ -8,7 +8,7 @@ using the modular pipeline architecture.
 
 from fastvideo.fastvideo_args import FastVideoArgs
 from fastvideo.logger import init_logger
-from fastvideo.pipelines.composed_pipeline_base import ComposedPipelineBase
+from fastvideo.pipelines.inference_pipeline import InferencePipeline
 from fastvideo.pipelines.stages import (ConditioningStage, DecodingStage,
                                         DenoisingStage, InputValidationStage,
                                         LatentPreparationStage,
@@ -20,7 +20,7 @@ from fastvideo.pipelines.stages import (ConditioningStage, DecodingStage,
 logger = init_logger(__name__)
 
 
-class HunyuanVideoPipeline(ComposedPipelineBase):
+class HunyuanVideoPipeline(InferencePipeline):
 
     _required_config_modules = [
         "text_encoder", "text_encoder_2", "tokenizer", "tokenizer_2", "vae",

--- a/fastvideo/pipelines/basic/stepvideo/stepvideo_pipeline.py
+++ b/fastvideo/pipelines/basic/stepvideo/stepvideo_pipeline.py
@@ -20,7 +20,6 @@ from fastvideo.logger import init_logger
 from fastvideo.models.encoders.bert import HunyuanClip  # type: ignore
 from fastvideo.models.encoders.stepllm import STEP1TextEncoder
 from fastvideo.models.loader.component_loader import PipelineComponentLoader
-from fastvideo.pipelines.composed_pipeline_base import ComposedPipelineBase
 from fastvideo.pipelines.lora_pipeline import LoRAPipeline
 from fastvideo.pipelines.stages import (DecodingStage, DenoisingStage,
                                         InputValidationStage,
@@ -31,7 +30,7 @@ from fastvideo.pipelines.stages import (DecodingStage, DenoisingStage,
 logger = init_logger(__name__)
 
 
-class StepVideoPipeline(LoRAPipeline, ComposedPipelineBase):
+class StepVideoPipeline(LoRAPipeline):
 
     _required_config_modules = ["transformer", "scheduler", "vae"]
 

--- a/fastvideo/pipelines/basic/wan/wan_causal_dmd_pipeline.py
+++ b/fastvideo/pipelines/basic/wan/wan_causal_dmd_pipeline.py
@@ -7,7 +7,7 @@ This module wires the causal DMD denoising stage into the modular pipeline.
 
 from fastvideo.fastvideo_args import FastVideoArgs
 from fastvideo.logger import init_logger
-from fastvideo.pipelines import ComposedPipelineBase, LoRAPipeline
+from fastvideo.pipelines import LoRAPipeline
 
 # isort: off
 from fastvideo.pipelines.stages import (ConditioningStage, DecodingStage,
@@ -20,7 +20,7 @@ from fastvideo.pipelines.stages import (ConditioningStage, DecodingStage,
 logger = init_logger(__name__)
 
 
-class WanCausalDMDPipeline(LoRAPipeline, ComposedPipelineBase):
+class WanCausalDMDPipeline(LoRAPipeline):
 
     _required_config_modules = [
         "text_encoder", "tokenizer", "vae", "transformer", "scheduler"

--- a/fastvideo/pipelines/basic/wan/wan_dmd_pipeline.py
+++ b/fastvideo/pipelines/basic/wan/wan_dmd_pipeline.py
@@ -10,7 +10,7 @@ from fastvideo.fastvideo_args import FastVideoArgs
 from fastvideo.logger import init_logger
 from fastvideo.models.schedulers.scheduling_flow_match_euler_discrete import (
     FlowMatchEulerDiscreteScheduler)
-from fastvideo.pipelines import ComposedPipelineBase, LoRAPipeline
+from fastvideo.pipelines import LoRAPipeline
 
 # isort: off
 from fastvideo.pipelines.stages import (ConditioningStage, DecodingStage,
@@ -23,7 +23,7 @@ from fastvideo.pipelines.stages import (ConditioningStage, DecodingStage,
 logger = init_logger(__name__)
 
 
-class WanDMDPipeline(LoRAPipeline, ComposedPipelineBase):
+class WanDMDPipeline(LoRAPipeline):
     """
     Wan video diffusion pipeline with LoRA support.
     """

--- a/fastvideo/pipelines/basic/wan/wan_i2v_dmd_pipeline.py
+++ b/fastvideo/pipelines/basic/wan/wan_i2v_dmd_pipeline.py
@@ -8,7 +8,6 @@ using the modular pipeline architecture.
 
 from fastvideo.fastvideo_args import FastVideoArgs
 from fastvideo.logger import init_logger
-from fastvideo.pipelines.composed_pipeline_base import ComposedPipelineBase
 from fastvideo.pipelines.lora_pipeline import LoRAPipeline
 
 # isort: off
@@ -23,7 +22,7 @@ from fastvideo.models.schedulers.scheduling_flow_match_euler_discrete import (
 logger = init_logger(__name__)
 
 
-class WanImageToVideoDmdPipeline(LoRAPipeline, ComposedPipelineBase):
+class WanImageToVideoDmdPipeline(LoRAPipeline):
 
     _required_config_modules = [
         "text_encoder", "tokenizer", "vae", "transformer", "scheduler", \

--- a/fastvideo/pipelines/basic/wan/wan_i2v_pipeline.py
+++ b/fastvideo/pipelines/basic/wan/wan_i2v_pipeline.py
@@ -8,7 +8,6 @@ using the modular pipeline architecture.
 
 from fastvideo.fastvideo_args import FastVideoArgs
 from fastvideo.logger import init_logger
-from fastvideo.pipelines.composed_pipeline_base import ComposedPipelineBase
 from fastvideo.pipelines.lora_pipeline import LoRAPipeline
 
 # isort: off
@@ -23,7 +22,7 @@ from fastvideo.models.schedulers.scheduling_flow_unipc_multistep import (
 logger = init_logger(__name__)
 
 
-class WanImageToVideoPipeline(LoRAPipeline, ComposedPipelineBase):
+class WanImageToVideoPipeline(LoRAPipeline):
 
     _required_config_modules = [
         "text_encoder", "tokenizer", "vae", "transformer", "scheduler", \

--- a/fastvideo/pipelines/basic/wan/wan_pipeline.py
+++ b/fastvideo/pipelines/basic/wan/wan_pipeline.py
@@ -10,7 +10,7 @@ from fastvideo.fastvideo_args import FastVideoArgs
 from fastvideo.logger import init_logger
 from fastvideo.models.schedulers.scheduling_flow_unipc_multistep import (
     FlowUniPCMultistepScheduler)
-from fastvideo.pipelines import ComposedPipelineBase, LoRAPipeline
+from fastvideo.pipelines import LoRAPipeline
 from fastvideo.pipelines.stages import (ConditioningStage, DecodingStage,
                                         DenoisingStage, InputValidationStage,
                                         LatentPreparationStage,
@@ -20,7 +20,7 @@ from fastvideo.pipelines.stages import (ConditioningStage, DecodingStage,
 logger = init_logger(__name__)
 
 
-class WanPipeline(LoRAPipeline, ComposedPipelineBase):
+class WanPipeline(LoRAPipeline):
     """
     Wan video diffusion pipeline with LoRA support.
     """

--- a/fastvideo/pipelines/composed_pipeline_base.py
+++ b/fastvideo/pipelines/composed_pipeline_base.py
@@ -89,23 +89,12 @@ class ComposedPipelineBase(ABC):
         if self.post_init_called:
             return
         self.post_init_called = True
-        if self.fastvideo_args.training_mode:
-            assert isinstance(self.fastvideo_args, TrainingArgs)
-            self.training_args = self.fastvideo_args
-            assert self.training_args is not None
-            self.initialize_training_pipeline(self.training_args)
-            if self.training_args.log_validation:
-                self.initialize_validation_pipeline(self.training_args)
+        self.setup_pipeline()
 
-        self.initialize_pipeline(self.fastvideo_args)
-        if self.fastvideo_args.enable_torch_compile:
-            self.modules["transformer"] = torch.compile(
-                self.modules["transformer"])
-            logger.info("Torch Compile enabled for DiT")
-
-        if not self.fastvideo_args.training_mode:
-            logger.info("Creating pipeline stages...")
-            self.create_pipeline_stages(self.fastvideo_args)
+    @abstractmethod
+    def setup_pipeline(self) -> None:
+        """Finalize pipeline initialization after modules are loaded."""
+        raise NotImplementedError
 
     def initialize_training_pipeline(self, training_args: TrainingArgs):
         raise NotImplementedError(

--- a/fastvideo/pipelines/inference_pipeline.py
+++ b/fastvideo/pipelines/inference_pipeline.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Inference-specific composed pipeline implementation."""
+
+import torch
+
+from fastvideo.fastvideo_args import FastVideoArgs
+from fastvideo.logger import init_logger
+
+from .composed_pipeline_base import ComposedPipelineBase
+
+logger = init_logger(__name__)
+
+
+class InferencePipeline(ComposedPipelineBase):
+    """Base class for inference pipelines built on top of composed pipelines."""
+
+    def setup_pipeline(self) -> None:
+        assert isinstance(self.fastvideo_args, FastVideoArgs)
+        if getattr(self.fastvideo_args, "training_mode", False):
+            raise RuntimeError(
+                "InferencePipeline requires training_mode to be False."
+            )
+
+        self.initialize_pipeline(self.fastvideo_args)
+
+        if self.fastvideo_args.enable_torch_compile:
+            self.modules["transformer"] = torch.compile(
+                self.modules["transformer"])
+            logger.info("Torch Compile enabled for DiT")
+
+        logger.info("Creating pipeline stages...")
+        self.create_pipeline_stages(self.fastvideo_args)
+
+
+__all__ = ["InferencePipeline"]

--- a/fastvideo/pipelines/lora_pipeline.py
+++ b/fastvideo/pipelines/lora_pipeline.py
@@ -16,13 +16,13 @@ from fastvideo.layers.lora.linear import (BaseLayerWithLoRA, get_lora_layer,
                                           replace_submodule)
 from fastvideo.logger import init_logger
 from fastvideo.models.loader.utils import get_param_names_mapping
-from fastvideo.pipelines.composed_pipeline_base import ComposedPipelineBase
+from fastvideo.pipelines.inference_pipeline import InferencePipeline
 from fastvideo.utils import maybe_download_lora
 
 logger = init_logger(__name__)
 
 
-class LoRAPipeline(ComposedPipelineBase):
+class LoRAPipeline(InferencePipeline):
     """
     Pipeline that supports injecting LoRA adapters into the diffusion transformer.
     TODO: support training.

--- a/fastvideo/pipelines/preprocess/preprocess_pipeline_base.py
+++ b/fastvideo/pipelines/preprocess/preprocess_pipeline_base.py
@@ -16,14 +16,14 @@ from fastvideo.dataset.preprocessing_datasets import PreprocessBatch
 from fastvideo.distributed import get_local_torch_device
 from fastvideo.fastvideo_args import FastVideoArgs
 from fastvideo.logger import init_logger
-from fastvideo.pipelines.composed_pipeline_base import ComposedPipelineBase
+from fastvideo.pipelines.inference_pipeline import InferencePipeline
 from fastvideo.pipelines.pipeline_batch_info import ForwardBatch
 from fastvideo.pipelines.stages import TextEncodingStage
 
 logger = init_logger(__name__)
 
 
-class BasePreprocessPipeline(ComposedPipelineBase):
+class BasePreprocessPipeline(InferencePipeline):
     """Base class for preprocessing pipelines that handles common functionality."""
 
     def create_pipeline_stages(self, fastvideo_args: FastVideoArgs):

--- a/fastvideo/pipelines/preprocess/wan/wan_preprocess_pipelines.py
+++ b/fastvideo/pipelines/preprocess/wan/wan_preprocess_pipelines.py
@@ -1,5 +1,6 @@
 from fastvideo.fastvideo_args import FastVideoArgs
-from fastvideo.pipelines.composed_pipeline_base import ComposedPipelineBase
+from fastvideo.fastvideo_args import FastVideoArgs
+from fastvideo.pipelines.inference_pipeline import InferencePipeline
 from fastvideo.pipelines.preprocess.preprocess_stages import (
     TextTransformStage, VideoTransformStage)
 from fastvideo.pipelines.stages import (EncodingStage, ImageEncodingStage,
@@ -7,7 +8,7 @@ from fastvideo.pipelines.stages import (EncodingStage, ImageEncodingStage,
 from fastvideo.pipelines.stages.image_encoding import ImageVAEEncodingStage
 
 
-class PreprocessPipelineI2V(ComposedPipelineBase):
+class PreprocessPipelineI2V(InferencePipeline):
     _required_config_modules = [
         "image_encoder", "image_processor", "text_encoder", "tokenizer", "vae"
     ]
@@ -50,7 +51,7 @@ class PreprocessPipelineI2V(ComposedPipelineBase):
                        stage=EncodingStage(vae=self.get_module("vae"), ))
 
 
-class PreprocessPipelineT2V(ComposedPipelineBase):
+class PreprocessPipelineT2V(InferencePipeline):
     _required_config_modules = ["text_encoder", "tokenizer", "vae"]
 
     def create_pipeline_stages(self, fastvideo_args: FastVideoArgs):

--- a/fastvideo/training/training_pipeline.py
+++ b/fastvideo/training/training_pipeline.py
@@ -79,6 +79,19 @@ class TrainingPipeline(LoRAPipeline, ABC):
         super().__init__(model_path, fastvideo_args, required_config_modules,
                          loaded_modules)  # type: ignore
 
+    def setup_pipeline(self) -> None:
+        assert isinstance(self.fastvideo_args, TrainingArgs)
+        self.training_args = self.fastvideo_args
+        self.initialize_training_pipeline(self.training_args)
+        if self.training_args.log_validation:
+            self.initialize_validation_pipeline(self.training_args)
+
+        self.initialize_pipeline(self.fastvideo_args)
+        if self.fastvideo_args.enable_torch_compile:
+            self.modules["transformer"] = torch.compile(
+                self.modules["transformer"])
+            logger.info("Torch Compile enabled for DiT")
+
     def create_pipeline_stages(self, fastvideo_args: FastVideoArgs):
         raise RuntimeError(
             "create_pipeline_stages should not be called for training pipeline")


### PR DESCRIPTION
## Summary
- add a dedicated `InferencePipeline` layer that handles inference-specific initialization
- update all inference and preprocess pipelines to inherit from the new base and refresh documentation
- move training-specific setup into `TrainingPipeline.setup_pipeline` to keep `ComposedPipelineBase` shared

## Testing
- python -m compileall fastvideo/pipelines fastvideo/training docs/source

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691588c6de88832b8ce884e7c5bdbdfa)