### PR TITLE
Bump PyTorch to 2.9.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "timm==1.0.11",
     "peft>=0.15.0",
     "diffusers>=0.33.1",
-    "torch==2.7.1",
+    "torch==2.9.0",
     "torchvision",
 
     # Acceleration & Optimization


### PR DESCRIPTION
## Summary
- update the pinned torch dependency to version 2.9.0

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938b442e324832b99aee53aaa4bf0ca)